### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Jacqueciber1970/juice-shop-ada-1466/security/code-scanning/54](https://github.com/Jacqueciber1970/juice-shop-ada-1466/security/code-scanning/54)

To fix this issue, the code should avoid using MongoDB's `$where` operator with user input. Instead of passing raw user data into a JavaScript condition, use parameterized queries for filtering. For this case, replace the `$where` query with a regular MongoDB equality match on the `orderId` field: `{ orderId: id }`. This change ensures user input is only used for direct comparison, not interpreted as code. Edit line 18 in `routes/trackOrder.ts` to use `.find({ orderId: id })`, and remove any unnecessary `$where` functionality. No additional imports are required; we just need to update the query syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
